### PR TITLE
Remove jack as a default feature on non-Linux platforms

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,7 +12,6 @@ approx = "0.5.1"
 async-trait = "0.1.89"
 async_zip = { version = "0.0.18", features = ["full"] }
 chrono = { version = "0.4.44", features = ["serde"] }
-cpal = { version = "0.17.1", features = ["jack"] }
 fern = "0.7.1"
 fixed = "1.31.0"
 futures = "0.3.32"
@@ -64,7 +63,11 @@ ui = [ "dep:iced" ]
 midi = [ "dep:midir" ]
 
 [target.'cfg(target_os = "linux")'.dependencies]
+cpal = { version = "0.17.1", features = ["jack"] }
 rppal = "0.22.1"
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+cpal = { version = "0.17.1" }
 
 [package.metadata.deb]
 maintainer = "Joe Noël <joe@joenoel.co.uk>"

--- a/core/README.md
+++ b/core/README.md
@@ -8,6 +8,14 @@ The core audio server built in Rust. Handles audio processing, looping, and MIDI
 cargo build
 ```
 
+## Build for Android
+
+Use no default features for Android so desktop UI and MIDI remain disabled:
+
+```sh
+cargo build --target aarch64-linux-android --no-default-features
+```
+
 ## Test
 
 ```sh

--- a/core/src/midi/fallback.rs
+++ b/core/src/midi/fallback.rs
@@ -1,7 +1,7 @@
 use log::info;
 use tokio::sync::mpsc;
 
-use crate::{model::Action, preferences::MidiPreferences};
+use crate::{bloop::MidiPreferences, model::Action};
 
 pub struct MidiController {}
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>