### PR TITLE
Fix iOS mDNS scanning

### DIFF
--- a/ios/source/core/Discovery.swift
+++ b/ios/source/core/Discovery.swift
@@ -12,7 +12,7 @@ class Discovery: NSObject {
     private var state: NWBrowser.State? = nil
 
     override init() {
-        let parameters = NWParameters()
+        let parameters = NWParameters.tcp
         parameters.includePeerToPeer = true
 
         let descriptor = NWBrowser.Descriptor.bonjour(type: "_bloop._tcp", domain: "local.")


### PR DESCRIPTION
## Summary

- configure the iOS Bonjour browser with TCP parameters
- preserve peer-to-peer discovery support

## Root cause

The browser was created with a generic `NWParameters()` instance even though `_bloop._tcp` is a TCP Bonjour service. That empty protocol configuration could observe a response triggered by another browser without reliably initiating its own TCP service browse.

Using `NWParameters.tcp` matches the advertised service and Apple's documented `NWBrowser` setup.

## Impact

The iOS app now actively browses for Bloop servers instead of depending on another mDNS client to trigger a response.

## Validation

- `git diff --check`
- reviewed the resulting one-line diff against Apple's Network framework Bonjour browser guidance
- iOS build and device-level mDNS verification were not available in the Linux runner

Closes #765